### PR TITLE
misc: Update for new GitHub organisation name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Setup GOPATH
       run: |
-        gopath_org=$(go env GOPATH)/src/github.com/intel/
+        gopath_org=$(go env GOPATH)/src/github.com/kata-containers/
         mkdir -p ${gopath_org}
         ln -s ${PWD} ${gopath_org}
     - name: Checkout code
@@ -27,14 +27,14 @@ jobs:
         $(go env GOPATH)/bin/gometalinter --install
     - name: Running gometalinter
       run: |
-        gopath_repo=$(go env GOPATH)/src/github.com/intel/govmm
+        gopath_repo=$(go env GOPATH)/src/github.com/kata-containers/govmm
         pushd ${gopath_repo}
         $(go env GOPATH)/bin/gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode --enable=staticcheck -enable=gas ./...
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gopath_repo=$(go env GOPATH)/src/github.com/intel/govmm
+        gopath_repo=$(go env GOPATH)/src/github.com/kata-containers/govmm
         pushd ${gopath_repo}
         go get github.com/mattn/goveralls
         $(go env GOPATH)/bin/goveralls -v -service=github

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 arch:
     - s390x
 
-go_import_path: github.com/intel/govmm
+go_import_path: github.com/kata-containers/govmm
 
 matrix:
   allow_failures:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,12 @@ We accept github pull requests.
 We request you give quality assurance some consideration by:
 
 * Adding go unit tests for changes where it makes sense.
-* Enabling [Travis CI](https://travis-ci.org/intel/govmm) on your github fork of Virtual Machine Manager for Go to get continuous integration feedback on your dev/test branches.
+* Enabling [Travis CI](https://travis-ci.org/kata-containers/govmm) on your github fork of Virtual Machine Manager for Go to get continuous integration feedback on your dev/test branches.
 
 ## Issue tracking
 
 If you have a problem, please let us know.  If it's a bug not already documented, by all means please [open an
-issue in github](https://github.com/intel/govmm/issues/new) so we all get visibility
+issue in github](https://github.com/kata-containers/govmm/issues/new) so we all get visibility
 the problem and work toward resolution.
 
 Any security issues discovered with govmm should be reported by following the instructions on https://01.org/security.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Virtual Machine Manager for Go
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/intel/govmm)](https://goreportcard.com/report/github.com/intel/govmm)
-[![Build Status](https://travis-ci.org/intel/govmm.svg?branch=master)](https://travis-ci.org/intel/govmm)
-[![GoDoc](https://godoc.org/github.com/intel/govmm/qemu?status.svg)](https://godoc.org/github.com/intel/govmm/qemu)
-[![Coverage Status](https://coveralls.io/repos/github/intel/govmm/badge.svg?branch=master)](https://coveralls.io/github/intel/govmm?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/govmm)](https://goreportcard.com/report/github.com/kata-containers/govmm)
+[![Build Status](https://travis-ci.org/kata-containers/govmm.svg?branch=master)](https://travis-ci.org/kata-containers/govmm)
+[![GoDoc](https://godoc.org/github.com/kata-containers/govmm/qemu?status.svg)](https://godoc.org/github.com/kata-containers/govmm/qemu)
+[![Coverage Status](https://coveralls.io/repos/github/kata-containers/govmm/badge.svg?branch=master)](https://coveralls.io/github/kata-containers/govmm?branch=master)
 
 Virtual Machine Manager for Go (govmm) is a suite of packages that
 provide Go APIs for creating and managing virtual machines.  There's
 currently support for only one hypervisor, qemu/kvm, support for which
-is provided by the github.com/intel/govmm/qemu package.
+is provided by the github.com/kata-containers/govmm/qemu package.
 
 The qemu package provides APIs for launching qemu instances and for
 managing those instances via QMP, once launched.  VM instances can

--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -21,7 +21,7 @@ import (
 
 	"context"
 
-	"github.com/intel/govmm/qemu"
+	"github.com/kata-containers/govmm/qemu"
 )
 
 func Example() {


### PR DESCRIPTION
`govmm` is now part of the `kata-containers` GitHub organisation, so
update to reflect this.

Fixes: #145.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>