### PR TITLE
Add serial ID to blk device

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1084,6 +1084,8 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf(",share-rw=on"))
 	}
 
+	deviceParams = append(deviceParams, fmt.Sprintf(",serial=%s", blkdev.ID))
+
 	blkParams = append(blkParams, fmt.Sprintf("id=%s", blkdev.ID))
 	blkParams = append(blkParams, fmt.Sprintf(",file=%s", blkdev.File))
 	blkParams = append(blkParams, fmt.Sprintf(",aio=%s", blkdev.AIO))

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -36,7 +36,7 @@ var (
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1,romfile=efi-virtio.rom"
 	deviceVhostUserSCSIString      = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1,romfile=efi-virtio.rom"
 	deviceVhostUserBlkString       = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2,romfile=efi-virtio.rom"
-	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom,share-rw=on -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
+	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom,share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff,romfile=efi-virtio.rom"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff,romfile=efi-virtio.rom"
 	romfile                        = "efi-virtio.rom"

--- a/qemu/qemu_s390x_test.go
+++ b/qemu/qemu_s390x_test.go
@@ -32,7 +32,7 @@ var (
 	deviceVFIOString               = "-device vfio-ccw,host=02:10.0,devno=" + DevNo
 	deviceSCSIControllerStr        = "-device virtio-scsi-ccw,id=foo,devno=" + DevNo
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
-	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
+	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff"
 	romfile                        = ""


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

I'm not sure if this change looks legit but I create my block device in this way:

```go
	var RAW qemu.BlockDeviceFormat = "raw"

	blk := qemu.BlockDevice{
		Driver:    qemu.VirtioBlock,
		ID:        "rootfs",
		AIO:       qemu.Threads,
		File:      "rootfs.img",
		Format:    RAW,
		Interface: qemu.NoInterface,
		Transport: qemu.TransportPCI,
	}
```

and the output parameters are:

```sh
-device virtio-blk-pci,disable-modern=false,drive=rootfs,scsi=off,config-wce=off,romfile=
-drive id=rootfs,file=rootfs.img,aio=threads,format=raw,if=none
```

In this way, my instance does not bootstrap but when I have `serial=rootfs` appended in `-device` then it works and it bootstrap successfully.