### PR TITLE
qemu: add pvpanic and dump guest memory support

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1118,6 +1118,24 @@ func (blkdev BlockDevice) deviceName(config *Config) string {
 	return string(blkdev.Driver)
 }
 
+// PVPanicDevice represents a qemu pvpanic device.
+type PVPanicDevice struct {
+	NoShutdown bool
+}
+
+// Valid always returns true for pvpanic device
+func (dev PVPanicDevice) Valid() bool {
+	return true
+}
+
+// QemuParams returns the qemu parameters built out of this serial device.
+func (dev PVPanicDevice) QemuParams(config *Config) []string {
+	if dev.NoShutdown {
+		return []string{"-device", "pvpanic", "-no-shutdown"}
+	}
+	return []string{"-device", "pvpanic"}
+}
+
 // VhostUserDevice represents a qemu vhost-user device meant to be passed
 // in to the guest
 type VhostUserDevice struct {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -1203,3 +1203,18 @@ func TestAppendFwcfg(t *testing.T) {
 	}
 	testAppend(fwcfg, fwcfgString, t)
 }
+
+func TestAppendPVPanicDevice(t *testing.T) {
+	testCases := []struct {
+		dev Device
+		out string
+	}{
+		{nil, ""},
+		{PVPanicDevice{}, "-device pvpanic"},
+		{PVPanicDevice{NoShutdown: true}, "-device pvpanic -no-shutdown"},
+	}
+
+	for _, tc := range testCases {
+		testAppend(tc.dev, tc.out, t)
+	}
+}

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -268,7 +268,7 @@ func (q *QMP) readLoop(fromVMCh chan<- []byte) {
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if q.cfg.Logger.V(1) {
-			q.cfg.Logger.Infof("%s", string(line))
+			q.cfg.Logger.Infof("read from QMP: %s", string(line))
 		}
 
 		// Since []byte channel type transfer slice info(include slice underlying array pointer, len, cap)
@@ -1653,4 +1653,15 @@ func (q *QMP) ExecQomGet(ctx context.Context, path, property string) (interface{
 	}
 
 	return response, nil
+}
+
+// ExecuteDumpGuestMemory dump guest memory to host
+func (q *QMP) ExecuteDumpGuestMemory(ctx context.Context, protocol string, paging bool, format string) error {
+	args := map[string]interface{}{
+		"protocol": protocol,
+		"paging":   paging,
+		"format":   format,
+	}
+
+	return q.executeCommand(ctx, "dump-guest-memory", args, nil)
 }

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1794,3 +1794,22 @@ func TestExecQomGet(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks dump-guest-memory
+func TestExecuteDumpGuestMemory(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("dump-guest-memory", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+
+	err := q.ExecuteDumpGuestMemory(context.Background(), "file:/tmp/dump.xxx.yyy", false, "elf")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	q.Shutdown()
+	<-disconnectedCh
+}


### PR DESCRIPTION
With this two features user can:

- Get event for GUEST_PANICKED
- Dump guest memory if needed

Fixes: #152 