### PR TITLE
qemu: enable "-pflash"

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2300,6 +2300,9 @@ type Config struct {
 	// Bios is the -bios parameter
 	Bios string
 
+	// PFlash specifies the parallel flash images (-pflash parameter)
+	PFlash []string
+
 	// Incoming controls migration source preparation
 	Incoming Incoming
 
@@ -2490,6 +2493,13 @@ func (config *Config) appendGlobalParam() {
 	}
 }
 
+func (config *Config) appendPFlashParam() {
+	for _, p := range config.PFlash {
+		config.qemuParams = append(config.qemuParams, "-pflash")
+		config.qemuParams = append(config.qemuParams, p)
+	}
+}
+
 func (config *Config) appendVGA() {
 	if config.VGA != "" {
 		config.qemuParams = append(config.qemuParams, "-vga")
@@ -2675,6 +2685,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendDevices()
 	config.appendRTC()
 	config.appendGlobalParam()
+	config.appendPFlashParam()
 	config.appendVGA()
 	config.appendKnobs()
 	config.appendKernel()

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -1023,6 +1024,25 @@ func TestBadGlobalParam(t *testing.T) {
 	c.appendGlobalParam()
 	if len(c.qemuParams) != 0 {
 		t.Errorf("Expected empty qemuParams, found %s", c.qemuParams)
+	}
+}
+
+func TestBadPFlash(t *testing.T) {
+	c := &Config{}
+	c.appendPFlashParam()
+	if len(c.qemuParams) != 0 {
+		t.Errorf("Expected empty qemuParams, found %s", c.qemuParams)
+	}
+}
+
+func TestValidPFlash(t *testing.T) {
+	c := &Config{}
+	c.PFlash = []string{"flash0", "flash1"}
+	c.appendPFlashParam()
+	expected := []string{"-pflash", "flash0", "-pflash", "flash1"}
+	ok := reflect.DeepEqual(expected, c.qemuParams)
+	if !ok {
+		t.Errorf("Expected %v, found %v", expected, c.qemuParams)
 	}
 }
 


### PR DESCRIPTION
flash image can store some critical data like firmware, enable it here.

Fixes: #140
Signed-off-by: Edmond AK Dantes <edmond.dantes.ak47@outlook.com>

@jodh-intel @jongwu @devimc 