### PR TITLE
qemu: add arm64 to support list of dimm

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -135,7 +135,7 @@ const (
 
 func isDimmSupported(config *Config) bool {
 	switch runtime.GOARCH {
-	case "amd64", "386", "ppc64le":
+	case "amd64", "386", "ppc64le", "arm64":
 		if config != nil && config.Machine.Type == MachineTypeMicrovm {
 			// microvm does not support NUMA
 			return false


### PR DESCRIPTION
dimm is supported on arm64, so add is to check list.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
Fixes: #155

@devimc @jodh-intel 