### PR TITLE
qemu: Append memory backend for non-DIMM setups

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2528,9 +2528,6 @@ func (config *Config) appendMemoryKnobs() {
 	if config.Memory.Size == "" {
 		return
 	}
-	if !isDimmSupported(config) {
-		return
-	}
 	var objMemParam, numaMemParam string
 	dimmName := "dimm1"
 	if config.Knobs.HugePages {
@@ -2553,8 +2550,13 @@ func (config *Config) appendMemoryKnobs() {
 	config.qemuParams = append(config.qemuParams, "-object")
 	config.qemuParams = append(config.qemuParams, objMemParam)
 
-	config.qemuParams = append(config.qemuParams, "-numa")
-	config.qemuParams = append(config.qemuParams, numaMemParam)
+	if isDimmSupported(config) {
+		config.qemuParams = append(config.qemuParams, "-numa")
+		config.qemuParams = append(config.qemuParams, numaMemParam)
+	} else {
+		config.qemuParams = append(config.qemuParams, "-machine")
+		config.qemuParams = append(config.qemuParams, "memory-backend="+dimmName)
+	}
 }
 
 func (config *Config) appendKnobs() {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -542,10 +542,6 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 }
 
 func TestAppendMemoryHugePages(t *testing.T) {
-	if !isDimmSupported(nil) {
-		t.Skip("Dimm not supported")
-	}
-
 	conf := &Config{
 		Memory: Memory{
 			Size:   "1G",
@@ -563,17 +559,22 @@ func TestAppendMemoryHugePages(t *testing.T) {
 		FileBackedMem: true,
 		MemShared:     true,
 	}
-	knobsString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=/dev/hugepages,share=on,prealloc=on -numa node,memdev=dimm1"
+	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=/dev/hugepages,share=on,prealloc=on"
+	numaMemString := "-numa node,memdev=dimm1"
+	memBackendString := "-machine memory-backend=dimm1"
 	mlockFalseString := "-realtime mlock=off"
+
+	knobsString := objMemString + " "
+	if isDimmSupported(nil) {
+		knobsString += numaMemString
+	} else {
+		knobsString += memBackendString
+	}
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
 }
 
 func TestAppendMemoryMemPrealloc(t *testing.T) {
-	if !isDimmSupported(nil) {
-		t.Skip("Dimm not supported")
-	}
-
 	conf := &Config{
 		Memory: Memory{
 			Size:   "1G",
@@ -589,17 +590,22 @@ func TestAppendMemoryMemPrealloc(t *testing.T) {
 		MemPrealloc: true,
 		MemShared:   true,
 	}
-	knobsString := "-object memory-backend-ram,id=dimm1,size=1G,share=on,prealloc=on -numa node,memdev=dimm1"
+	objMemString := "-object memory-backend-ram,id=dimm1,size=1G,share=on,prealloc=on"
+	numaMemString := "-numa node,memdev=dimm1"
+	memBackendString := "-machine memory-backend=dimm1"
 	mlockFalseString := "-realtime mlock=off"
+
+	knobsString := objMemString + " "
+	if isDimmSupported(nil) {
+		knobsString += numaMemString
+	} else {
+		knobsString += memBackendString
+	}
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
 }
 
 func TestAppendMemoryMemShared(t *testing.T) {
-	if !isDimmSupported(nil) {
-		t.Skip("Dimm not supported")
-	}
-
 	conf := &Config{
 		Memory: Memory{
 			Size:   "1G",
@@ -615,17 +621,22 @@ func TestAppendMemoryMemShared(t *testing.T) {
 		FileBackedMem: true,
 		MemShared:     true,
 	}
-	knobsString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar,share=on -numa node,memdev=dimm1"
+	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar,share=on"
+	numaMemString := "-numa node,memdev=dimm1"
+	memBackendString := "-machine memory-backend=dimm1"
 	mlockFalseString := "-realtime mlock=off"
+
+	knobsString := objMemString + " "
+	if isDimmSupported(nil) {
+		knobsString += numaMemString
+	} else {
+		knobsString += memBackendString
+	}
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
 }
 
 func TestAppendMemoryFileBackedMem(t *testing.T) {
-	if !isDimmSupported(nil) {
-		t.Skip("Dimm not supported")
-	}
-
 	conf := &Config{
 		Memory: Memory{
 			Size:   "1G",
@@ -641,17 +652,22 @@ func TestAppendMemoryFileBackedMem(t *testing.T) {
 		FileBackedMem: true,
 		MemShared:     false,
 	}
-	knobsString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar -numa node,memdev=dimm1"
+	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar"
+	numaMemString := "-numa node,memdev=dimm1"
+	memBackendString := "-machine memory-backend=dimm1"
 	mlockFalseString := "-realtime mlock=off"
+
+	knobsString := objMemString + " "
+	if isDimmSupported(nil) {
+		knobsString += numaMemString
+	} else {
+		knobsString += memBackendString
+	}
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
 }
 
 func TestAppendMemoryFileBackedMemPrealloc(t *testing.T) {
-	if !isDimmSupported(nil) {
-		t.Skip("Dimm not supported")
-	}
-
 	conf := &Config{
 		Memory: Memory{
 			Size:   "1G",
@@ -668,8 +684,17 @@ func TestAppendMemoryFileBackedMemPrealloc(t *testing.T) {
 		MemShared:     true,
 		MemPrealloc:   true,
 	}
-	knobsString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar,share=on,prealloc=on -numa node,memdev=dimm1"
+	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar,share=on,prealloc=on"
+	numaMemString := "-numa node,memdev=dimm1"
+	memBackendString := "-machine memory-backend=dimm1"
 	mlockFalseString := "-realtime mlock=off"
+
+	knobsString := objMemString + " "
+	if isDimmSupported(nil) {
+		knobsString += numaMemString
+	} else {
+		knobsString += memBackendString
+	}
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
 }


### PR DESCRIPTION
Some architectures and setups do not support DIMM/NUMA. However, they
can still use memory backends, provided a memory backend of the same ID
is specified under -machine. Enable this functionality in
appendMemoryKnobs.

Fixes: #160

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>