### PR TITLE
qemu: support QEMU 6

### DIFF
--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -34,7 +34,7 @@ func Example() {
 	// kvm
 	params = append(params, "-enable-kvm", "-cpu", "host")
 	// qmp socket
-	params = append(params, "-daemonize", "-qmp", "unix:/tmp/qmp-socket,server,nowait")
+	params = append(params, "-daemonize", "-qmp", "unix:/tmp/qmp-socket,server=on,wait=off")
 	// resources
 	params = append(params, "-m", "370", "-smp", "cpus=2")
 

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -552,7 +552,7 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	cdevParams = append(cdevParams, string(cdev.Backend))
 	cdevParams = append(cdevParams, fmt.Sprintf(",id=%s", cdev.ID))
 	if cdev.Backend == Socket {
-		cdevParams = append(cdevParams, fmt.Sprintf(",path=%s,server,nowait", cdev.Path))
+		cdevParams = append(cdevParams, fmt.Sprintf(",path=%s,server=on,wait=off", cdev.Path))
 	} else {
 		cdevParams = append(cdevParams, fmt.Sprintf(",path=%s", cdev.Path))
 	}
@@ -2385,9 +2385,9 @@ func (config *Config) appendQMPSockets() {
 		qmpParams := append([]string{}, fmt.Sprintf("%s:", q.Type))
 		qmpParams = append(qmpParams, q.Name)
 		if q.Server {
-			qmpParams = append(qmpParams, ",server")
+			qmpParams = append(qmpParams, ",server=on")
 			if q.NoWait {
-				qmpParams = append(qmpParams, ",nowait")
+				qmpParams = append(qmpParams, ",wait=off")
 			}
 		}
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -288,7 +288,7 @@ func TestAppendDeviceSerial(t *testing.T) {
 	testAppend(sdev, deviceSerialString, t)
 }
 
-var deviceSerialPortString = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server,nowait"
+var deviceSerialPortString = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server=on,wait=off"
 
 func TestAppendDeviceSerialPort(t *testing.T) {
 	chardev := CharDevice{
@@ -741,7 +741,7 @@ func TestFailToAppendCPUs(t *testing.T) {
 	}
 }
 
-var qmpSingleSocketServerString = "-qmp unix:cc-qmp,server,nowait"
+var qmpSingleSocketServerString = "-qmp unix:cc-qmp,server=on,wait=off"
 var qmpSingleSocketString = "-qmp unix:cc-qmp"
 
 func TestAppendSingleQMPSocketServer(t *testing.T) {
@@ -765,7 +765,7 @@ func TestAppendSingleQMPSocket(t *testing.T) {
 	testAppend(qmp, qmpSingleSocketString, t)
 }
 
-var qmpSocketServerString = "-qmp unix:cc-qmp-1,server,nowait -qmp unix:cc-qmp-2,server,nowait"
+var qmpSocketServerString = "-qmp unix:cc-qmp-1,server=on,wait=off -qmp unix:cc-qmp-2,server=on,wait=off"
 
 func TestAppendQMPSocketServer(t *testing.T) {
 	qmp := []QMPSocket{


### PR DESCRIPTION
Use `on` and `off` to enable or disable features,
`no` prefix is deprecated

Signed-off-by: Julio Montes <julio.montes@intel.com>