### PR TITLE
qmp: remove chatty log

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -267,10 +267,6 @@ func (q *QMP) readLoop(fromVMCh chan<- []byte) {
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		if q.cfg.Logger.V(1) {
-			q.cfg.Logger.Infof("read from QMP: %s", string(line))
-		}
-
 		// Since []byte channel type transfer slice info(include slice underlying array pointer, len, cap)
 		// between channel sender and receiver. scanner.Bytes() returned slice's underlying array
 		// may point to data that will be overwritten by a subsequent call to Scan(reference from:
@@ -442,7 +438,6 @@ func (q *QMP) writeNextQMPCommand(cmdQueue *list.List) {
 		}
 		cmdQueue.Remove(cmdEl)
 	}
-	q.cfg.Logger.Infof("%s", string(encodedCmd))
 	encodedCmd = append(encodedCmd, '\n')
 	if unixConn, ok := q.conn.(*net.UnixConn); ok && len(cmd.oob) > 0 {
 		_, _, err = unixConn.WriteMsgUnix(encodedCmd, cmd.oob, nil)


### PR DESCRIPTION
In Kata, we are getting a *lot* of logs at runtime from QMP, in particular `read from QMP: xxxx`

Ideally we'd set this to only be visible for trace, but I did not see this working when adding a
V(7) check around these prints. To avoid filling journal with info that isn't useful, let's drop.

Fixes: #165

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>