### PR TITLE
qemu: Add support for Secure Execution

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -233,6 +233,9 @@ const (
 
 	// SEVGuest represents an SEV guest object
 	SEVGuest ObjectType = "sev-guest"
+
+	// SecExecGuest represents an s390x Secure Execution (Protected Virtualization in QEMU) object
+	SecExecGuest ObjectType = "s390-pv-guest"
 )
 
 // Object is a qemu object representation.
@@ -280,6 +283,8 @@ func (object Object) Valid() bool {
 		return object.ID != "" && object.File != "" && object.DeviceID != ""
 	case SEVGuest:
 		return object.ID != "" && object.File != "" && object.CBitPos != 0 && object.ReducedPhysBits != 0
+	case SecExecGuest:
+		return object.ID != ""
 	default:
 		return false
 	}
@@ -319,6 +324,9 @@ func (object Object) QemuParams(config *Config) []string {
 
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf(",file=%s", object.File))
+	case SecExecGuest:
+		objectParams = append(objectParams, string(object.Type))
+		objectParams = append(objectParams, fmt.Sprintf(",id=%s", object.ID))
 	}
 
 	if len(deviceParams) > 0 {

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -275,24 +275,14 @@ type Object struct {
 func (object Object) Valid() bool {
 	switch object.Type {
 	case MemoryBackendFile:
-		if object.ID == "" || object.MemPath == "" || object.Size == 0 {
-			return false
-		}
-
+		return object.ID != "" && object.MemPath != "" && object.Size != 0
 	case TDXGuest:
-		if object.ID == "" || object.File == "" || object.DeviceID == "" {
-			return false
-		}
+		return object.ID != "" && object.File != "" && object.DeviceID != ""
 	case SEVGuest:
-		if object.ID == "" || object.File == "" || object.CBitPos == 0 || object.ReducedPhysBits == 0 {
-			return false
-		}
-
+		return object.ID != "" && object.File != "" && object.CBitPos != 0 && object.ReducedPhysBits != 0
 	default:
 		return false
 	}
-
-	return true
 }
 
 // QemuParams returns the qemu parameters built out of this Object device.


### PR DESCRIPTION
Secure Execution, also known as Protected Virtualization in QEMU, is a 
confidential computing technology for s390x (IBM Z). Allow the
respective object.

Fixes: #172
Depends-on: #167 because when adding an object, it enables adding device parameters only when actually using a device ([relevant lines here](https://github.com/kata-containers/govmm/pull/167/files#diff-60d10e04edc58668f13d9932884322892005f9b39db600185b0b08872c750579R333-R336)), which is also required for Secure Execution. Should be rebased accordingly, which would effectively reduce this PR by that commit.

/cc @sameo @jimcadden @fitzthum
