### PR TITLE
qemu: Allow hot-plugging memory devices on PCI bridges

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1386,7 +1386,7 @@ func (q *QMP) ExecQueryCpusFast(ctx context.Context) ([]CPUInfoFast, error) {
 }
 
 // ExecMemdevAdd adds size of MiB memory device to the guest
-func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, size int, share bool, driver, driverID string) error {
+func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, size int, share bool, driver, driverID, addr, bus string) error {
 	props := map[string]interface{}{"size": uint64(size) << 20}
 	args := map[string]interface{}{
 		"qom-type": qomtype,
@@ -1419,6 +1419,14 @@ func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, si
 		"id":     driverID,
 		"memdev": id,
 	}
+
+	if bus != "" {
+		args["bus"] = bus
+	}
+	if addr != "" {
+		args["addr"] = addr
+	}
+
 	err = q.executeCommand(ctx, "device_add", args, nil)
 
 	return err
@@ -1426,7 +1434,7 @@ func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, si
 
 // ExecHotplugMemory adds size of MiB memory to the guest
 func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int, share bool) error {
-	return q.ExecMemdevAdd(ctx, qomtype, id, mempath, size, share, "pc-dimm", "dimm"+id)
+	return q.ExecMemdevAdd(ctx, qomtype, id, mempath, size, share, "pc-dimm", "dimm"+id, "", "")
 }
 
 // ExecuteNVDIMMDeviceAdd adds a block device to a QEMU instance using

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1342,7 +1342,7 @@ func TestExecMemdevAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecMemdevAdd(context.Background(), "memory-backend-ram", "mem0", "", 128, true, "virtio-mem-pci", "virtiomem0")
+	err := q.ExecMemdevAdd(context.Background(), "memory-backend-ram", "mem0", "", 128, true, "virtio-mem-pci", "virtiomem0", "0x1", "pci-bridge-0")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
Currently virtio-mem-pci devices can be hotplugged only on the root bus.
This doesn't work for PCIe machines like q35.

Extend the API to optionally support hotplugging on PCI bridges.

Fixes: #176

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>