### PR TITLE
qemu: Fix iommu_platform for CCW

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1435,6 +1435,9 @@ func (vhostuserDev VhostUserDevice) QemuFSParams(config *Config) []string {
 		deviceParams = append(deviceParams, "versiontable=/dev/shm/fuse_shared_versions")
 	}
 	if vhostuserDev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, "iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", vhostuserDev.DevNo))
 	}
 	if vhostuserDev.Transport.isVirtioPCI(config) && vhostuserDev.ROMFile != "" {


### PR DESCRIPTION
- Remove extra comma when device parameters are already joined with
  commas
- Enable iommu_platform for vhost user devices

Fixes: #178

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>