### PR TITLE
qemu: support multiple global parameters

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2465,7 +2465,7 @@ type Config struct {
 	SMP SMP
 
 	// GlobalParam is the -global parameter.
-	GlobalParam string
+	GlobalParam []string
 
 	// Knobs is a set of qemu boolean settings.
 	Knobs Knobs
@@ -2660,9 +2660,9 @@ func (config *Config) appendRTC() {
 }
 
 func (config *Config) appendGlobalParam() {
-	if config.GlobalParam != "" {
+	for _, param := range config.GlobalParam {
 		config.qemuParams = append(config.qemuParams, "-global")
-		config.qemuParams = append(config.qemuParams, config.GlobalParam)
+		config.qemuParams = append(config.qemuParams, param)
 	}
 }
 


### PR DESCRIPTION
make the GlobalParam a string slice, and range the slice to prepend a
"-global" before each string, when append global parameters.

Fix: #182

Signed-off-by: f00231050 <shaobao.feng@huawei.com>