### PR TITLE
add support for "sandbox" feature to qemu

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2448,6 +2448,9 @@ type Config struct {
 	// CPUModel is the CPU model to be used by qemu.
 	CPUModel string
 
+	// SeccompSandbox is the qemu function which enables the seccomp feature
+	SeccompSandbox string
+
 	// Machine
 	Machine Machine
 
@@ -2522,6 +2525,13 @@ func (config *Config) appendFDs(fds []*os.File) []int {
 	}
 
 	return fdInts
+}
+
+func (config *Config) appendSeccompSandbox() {
+	if config.SeccompSandbox != "" {
+		config.qemuParams = append(config.qemuParams, "-sandbox")
+		config.qemuParams = append(config.qemuParams, config.SeccompSandbox)
+	}
 }
 
 func (config *Config) appendName() {
@@ -2877,6 +2887,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendPidFile()
 	config.appendLogFile()
 	config.appendFwCfg(logger)
+	config.appendSeccompSandbox()
 
 	if err := config.appendCPUs(); err != nil {
 		return "", err

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -1072,6 +1072,25 @@ func TestValidPFlash(t *testing.T) {
 	}
 }
 
+func TestBadSeccompSandbox(t *testing.T) {
+	c := &Config{}
+	c.appendSeccompSandbox()
+	if len(c.qemuParams) != 0 {
+		t.Errorf("Expected empty qemuParams, found %s", c.qemuParams)
+	}
+}
+
+func TestValidSeccompSandbox(t *testing.T) {
+	c := &Config{}
+	c.SeccompSandbox = string("on,obsolete=deny")
+	c.appendSeccompSandbox()
+	expected := []string{"-sandbox", "on,obsolete=deny"}
+	ok := reflect.DeepEqual(expected, c.qemuParams)
+	if !ok {
+		t.Errorf("Expected %v, found %v", expected, c.qemuParams)
+	}
+}
+
 func TestBadVGA(t *testing.T) {
 	c := &Config{}
 	c.appendVGA()


### PR DESCRIPTION
Update the govmm code in order to support "sandbox" feature on qemu,
which can introduce another protect layer on the host,
to make the secure container more secure.

Fixes: #185

Signed-off-by: Liang Zhou <zhoul110@chinatelecom.cn>