### PR TITLE
qemu: support read-only nvdimm

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -277,6 +277,9 @@ type Object struct {
 	// ReducedPhysBits is the reduction in the guest physical address space
 	// This is only relevant for sev-guest objects
 	ReducedPhysBits uint32
+
+	// ReadOnly specifies whether `MemPath` is opened read-only or read/write (default)
+	ReadOnly bool
 }
 
 // Valid returns true if the Object structure is valid and complete.
@@ -315,6 +318,11 @@ func (object Object) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, string(object.Driver))
 		deviceParams = append(deviceParams, fmt.Sprintf("id=%s", object.DeviceID))
 		deviceParams = append(deviceParams, fmt.Sprintf("memdev=%s", object.ID))
+
+		if object.ReadOnly {
+			objectParams = append(objectParams, "readonly=on")
+			deviceParams = append(deviceParams, "unarmed=on")
+		}
 	case TDXGuest:
 		objectParams = append(objectParams, string(object.Type))
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -128,7 +128,7 @@ func TestAppendEmptyMachine(t *testing.T) {
 	testAppend(machine, "", t)
 }
 
-var deviceNVDIMMString = "-device nvdimm,id=nv0,memdev=mem0 -object memory-backend-file,id=mem0,mem-path=/root,size=65536"
+var deviceNVDIMMString = "-device nvdimm,id=nv0,memdev=mem0,unarmed=on -object memory-backend-file,id=mem0,mem-path=/root,size=65536,readonly=on"
 
 func TestAppendDeviceNVDIMM(t *testing.T) {
 	object := Object{
@@ -138,6 +138,7 @@ func TestAppendDeviceNVDIMM(t *testing.T) {
 		ID:       "mem0",
 		MemPath:  "/root",
 		Size:     1 << 16,
+		ReadOnly: true,
 	}
 
 	testAppend(object, deviceNVDIMMString, t)


### PR DESCRIPTION
Append `readonly=on` to a `memory-backend-file` object and
`unarmed=on` to a `nvdimm` device when `ReadOnly` is set to `true`

Signed-off-by: Julio Montes <julio.montes@intel.com>