### PR TITLE
Use 'host_device' driver for blockdev backends

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -775,7 +775,7 @@ func (q *QMP) blockdevAddBaseArgs(device, blockdevID string, ro bool) (map[strin
 		"driver":    "raw",
 		"read-only": ro,
 		"file": map[string]interface{}{
-			"driver":   "file",
+			"driver":   "host_device",
 			"filename": device,
 		},
 	}


### PR DESCRIPTION
ExecuteBlockdevAdd() and ExecuteBlockdevAddWithCache() both appear to be
intended to create block devices in the guest which backend onto a block
device in the host. That seems to be the way that Kata always uses it.
However blockdevAddBaseArgs(), used by both those functions always uses the
"file" driver, which is only intended for use with regular file backends.

Use of the "file" driver for host block devices was deprecated in qemu-3.0,
and has been removed entirely in qemu-6.0 (commit 8d17adf34f5).  We should
be using the "host_device" driver instead.

fixes #191

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>