### PR TITLE
Don't use deprecated 'props' argument to QMP 'object-add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 Virtual Machine Manager for Go (govmm) is a suite of packages that
 provide Go APIs for creating and managing virtual machines.  There's
-currently support for only one hypervisor, qemu/kvm, support for which
-is provided by the github.com/kata-containers/govmm/qemu package.
+currently support for only one hypervisor, qemu/kvm (version 5.0 and
+later), support for which is provided by the
+github.com/kata-containers/govmm/qemu package.
 
 The qemu package provides APIs for launching qemu instances and for
 managing those instances via QMP, once launched.  VM instances can

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1366,17 +1366,16 @@ func (q *QMP) ExecQueryCpusFast(ctx context.Context) ([]CPUInfoFast, error) {
 
 // ExecMemdevAdd adds size of MiB memory device to the guest
 func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, size int, share bool, driver, driverID, addr, bus string) error {
-	props := map[string]interface{}{"size": uint64(size) << 20}
 	args := map[string]interface{}{
 		"qom-type": qomtype,
 		"id":       id,
-		"props":    props,
+		"size":     uint64(size) << 20,
 	}
 	if mempath != "" {
-		props["mem-path"] = mempath
+		args["mem-path"] = mempath
 	}
 	if share {
-		props["share"] = true
+		args["share"] = true
 	}
 	err := q.executeCommand(ctx, "object-add", args, nil)
 	if err != nil {
@@ -1426,16 +1425,13 @@ func (q *QMP) ExecuteNVDIMMDeviceAdd(ctx context.Context, id, mempath string, si
 	args := map[string]interface{}{
 		"qom-type": "memory-backend-file",
 		"id":       "nvdimmbackmem" + id,
-		"props": map[string]interface{}{
-			"mem-path": mempath,
-			"size":     size,
-			"share":    true,
-		},
+		"mem-path": mempath,
+		"size":     size,
+		"share":    true,
 	}
 
 	if pmem != nil {
-		props := args["props"].(map[string]interface{})
-		props["pmem"] = *pmem
+		args["pmem"] = *pmem
 	}
 
 	err := q.executeCommand(ctx, "object-add", args, nil)

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1125,10 +1125,6 @@ func TestQMPCPUDeviceAdd(t *testing.T) {
 	dieID := "0"
 	coreID := "1"
 	threadID := "0"
-	version := &QMPVersion{
-		Major: 4,
-		Minor: 1,
-	}
 	for _, d := range drivers {
 		connectedCh := make(chan *QMPVersion)
 		disconnectedCh := make(chan struct{})
@@ -1137,7 +1133,6 @@ func TestQMPCPUDeviceAdd(t *testing.T) {
 		cfg := QMPConfig{Logger: qmpTestLogger{}}
 		q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 		checkVersion(t, connectedCh)
-		q.version = version
 		err := q.ExecuteCPUDeviceAdd(context.Background(), d, cpuID, socketID, dieID, coreID, threadID, "")
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
@@ -1634,10 +1629,6 @@ func TestExecuteNVDIMMDeviceAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	q.version = &QMPVersion{
-		Major: 4,
-		Minor: 1,
-	}
 	pmem := true
 	err := q.ExecuteNVDIMMDeviceAdd(context.Background(), "nvdimm0", "/dev/rbd0", 1024, &pmem)
 	if err != nil {


### PR DESCRIPTION
For both memory and NVDIMM adds, govmm needs to add memory-backend-file objects using the object-add qmp command.

Currently, govmm puts various properties for the new object in the props field of the args field to the basic QMP request. However use of props has been deprecated in qemu since 5.0 (commit 5f07c4d60d09) and is removed entirely in qemu 6.0 (commit 50243407457a).

Since relying on this new behaviour requires QEMU >= 5.0 anyway - and Kata requires that anyway - drop support for older QEMU versions.