### PR TITLE
govmm/qemu: Let IO/memory reservations be specified for bridge devices

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1802,6 +1802,15 @@ type BridgeDevice struct {
 
 	// ROMFile specifies the ROM file being used for this device.
 	ROMFile string
+
+	// Address range reservations for devices behind the bridge
+	// NB: strings seem an odd choice, but if they were integers,
+	// they'd default to 0 by Go's rules in all the existing users
+	// who don't set them.  0 is a valid value for certain cases,
+	// but not you want by default.
+	IOReserve     string
+	MemReserve    string
+	Pref64Reserve string
 }
 
 // Valid returns true if the BridgeDevice structure is valid and complete.
@@ -1850,6 +1859,16 @@ func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 	var transport VirtioTransport
 	if transport.isVirtioPCI(config) && bridgeDev.ROMFile != "" {
 		deviceParams = append(deviceParams, fmt.Sprintf("romfile=%s", bridgeDev.ROMFile))
+	}
+
+	if bridgeDev.IOReserve != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("io-reserve=%s", bridgeDev.IOReserve))
+	}
+	if bridgeDev.MemReserve != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("mem-reserve=%s", bridgeDev.MemReserve))
+	}
+	if bridgeDev.Pref64Reserve != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("pref64-reserve=%s", bridgeDev.Pref64Reserve))
 	}
 
 	qemuParams = append(qemuParams, "-device")

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 /*
@@ -38,6 +39,7 @@ var (
 	deviceVhostUserBlkString       = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2,romfile=efi-virtio.rom"
 	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom,share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff,romfile=efi-virtio.rom"
+	devicePCIBridgeStringReserved  = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=off,addr=ff,romfile=efi-virtio.rom,io-reserve=4k,mem-reserve=1m,pref64-reserve=1m"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff,romfile=efi-virtio.rom"
 	romfile                        = "efi-virtio.rom"
 )

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -486,6 +486,24 @@ func TestAppendPCIBridgeDevice(t *testing.T) {
 	testAppend(bridge, devicePCIBridgeString, t)
 }
 
+func TestAppendPCIBridgeDeviceWithReservations(t *testing.T) {
+
+	bridge := BridgeDevice{
+		Type:          PCIBridge,
+		ID:            "mybridge",
+		Bus:           "/pci-bus/pcie.0",
+		Addr:          "255",
+		Chassis:       5,
+		SHPC:          false,
+		ROMFile:       romfile,
+		IOReserve:     "4k",
+		MemReserve:    "1m",
+		Pref64Reserve: "1m",
+	}
+
+	testAppend(bridge, devicePCIBridgeStringReserved, t)
+}
+
 func TestAppendPCIEBridgeDevice(t *testing.T) {
 
 	bridge := BridgeDevice{


### PR DESCRIPTION
This adds fields to BridgeDevice struct to allow qemu's io-reserve,
mem-reserve and pref64-reserve properties to be set for PCI bridges.  This
is needed for Kata's upcoming change to ACPI hotplug.

fixes #200

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>