### PR TITLE
Add clean shutdown support

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2402,7 +2402,11 @@ type Knobs struct {
 	Realtime bool
 
 	// Exit instead of rebooting
+	// Prevents QEMU from rebooting in the event of a Triple Fault.
 	NoReboot bool
+
+	// Don’t exit QEMU on guest shutdown, but instead only stop the emulation.
+	NoShutdown bool
 
 	// IOMMUPlatform will enable IOMMU for supported devices
 	IOMMUPlatform bool
@@ -2774,6 +2778,10 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoReboot {
 		config.qemuParams = append(config.qemuParams, "--no-reboot")
+	}
+
+	if config.Knobs.NoShutdown {
+		config.qemuParams = append(config.qemuParams, "--no-shutdown")
 	}
 
 	if config.Knobs.Daemonize {

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -761,7 +761,7 @@ func (q *QMP) ExecuteCont(ctx context.Context) error {
 // This function will block until the SHUTDOWN event is received.
 func (q *QMP) ExecuteSystemPowerdown(ctx context.Context) error {
 	filter := &qmpEventFilter{
-		eventName: "SHUTDOWN",
+		eventName: "POWERDOWN",
 	}
 	return q.executeCommand(ctx, "system_powerdown", nil, filter)
 }

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -802,7 +802,7 @@ func TestQMPSystemPowerdown(t *testing.T) {
 	disconnectedCh := make(chan struct{})
 	buf := newQMPTestCommandBuffer(t)
 	buf.AddCommand("system_powerdown", nil, "return", nil)
-	buf.AddEvent("SHUTDOWN", time.Millisecond*100,
+	buf.AddEvent("POWERDOWN", time.Millisecond*100,
 		nil,
 		map[string]interface{}{
 			"seconds":      seconds,


### PR DESCRIPTION
## Allow VM To be terminated without shutting down QEMU

 Add support for --no-shutdown knob

```Don't exit QEMU on guest shutdown, but instead only stop the emulation.```

## Bugfix: ExecuteSystemPowerdown event

ExecuteSystemPowerdown issues `system_powerdown` and waits for `SHUTDOWN`. The event emitted is `POWERDOWN` per spec.

Without this we get an error even though the VM has shutdown  gracefully.

Per QEMU spec:

    ```

    POWERDOWN (Event)

    Emitted when the virtual machine is powered down through the power
    control system, such as via ACPI.

    Since

    0.12

    Example

    <- { "event": "POWERDOWN",
         "timestamp": { "seconds": 1267040730, "microseconds": 682951 } }

    SHUTDOWN (Event)

    Emitted when the virtual machine has shut down, indicating that qemu is
    about to exit.

    Arguments

    guest: boolean
    If true, the shutdown was triggered by a guest request (such as a
    guest-initiated ACPI shutdown request or other hardware-specific action)
    rather than a host request (such as sending qemu a SIGINT). (since 2.10)
    reason: ShutdownCause
    The ShutdownCause which resulted in the SHUTDOWN. (since 4.0)
    Note

    If the command-line option “-no-shutdown” has been specified, qemu will
    not exit, and a STOP event will eventually follow the SHUTDOWN event
    Since

    0.12

    Example

    <- { "event": "SHUTDOWN", "data": { "guest": true },
         "timestamp": { "seconds": 1267040730, "microseconds": 682951 } }

    ```

    Signed-off-by: Manohar Castelino <mcastelino@apple.com>
